### PR TITLE
ExternalID is no longer publicly settable, to reduce confusion

### DIFF
--- a/Calendars/Calendars.Plugin.Abstractions/Calendar.cs
+++ b/Calendars/Calendars.Plugin.Abstractions/Calendar.cs
@@ -19,7 +19,7 @@
         /// <summary>
         /// Platform-specific unique calendar identifier
         /// </summary>
-        public string ExternalID { get; set; }
+        public string ExternalID { get; internal set; }
 
         /// <summary>
         /// Whether or not the calendar itself (name/color) can be edited

--- a/Calendars/Calendars.Plugin.Abstractions/CalendarEvent.cs
+++ b/Calendars/Calendars.Plugin.Abstractions/CalendarEvent.cs
@@ -46,7 +46,7 @@ namespace Plugin.Calendars.Abstractions
         /// Platform-specific unique calendar event identifier
         /// </summary>
         /// <remarks>This ID will be the same for each instance of a recurring event.</remarks>
-        public string ExternalID { get; set; }
+        public string ExternalID { get; internal set; }
         
 
         /// <summary>

--- a/Calendars/Calendars.Plugin.Abstractions/Properties/AssemblyInfo.cs
+++ b/Calendars/Calendars.Plugin.Abstractions/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Plugin.Calendars")]
+[assembly: InternalsVisibleTo("CalendarsPluginiOSUnifiedTests")]
+[assembly: InternalsVisibleTo("Calendars.Plugin.Android.Tests")]
+[assembly: InternalsVisibleTo("Calendars.Plugin.UWP.Tests")]


### PR DESCRIPTION
It was not clear that this was not supposed to be populated when adding a new event.

The potential catch is that updating an existing event will require first retrieving that event, but that's probably the normal scenario anyhow... 