### PR TITLE
Missing xml doc which was referenced in the nuspec

### DIFF
--- a/Calendars.nuspec
+++ b/Calendars.nuspec
@@ -56,8 +56,8 @@ Android all-day events are no longer affected by timezone.
 
      <!--Universal Windows Platform-->
      <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.dll" target="lib\UAP10\Plugin.Calendars.dll" />
-     <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.pdb" target="lib\UAP10\Plugin.Calendars.pdxmlb" />
-     <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.xml" target="lib\UAP10\Plugin.Calendars.pdb" />
+     <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.pdb" target="lib\UAP10\Plugin.Calendars.pdb" />
+     <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.xml" target="lib\UAP10\Plugin.Calendars.xml" />
      <file src="Calendars\Calendars.Plugin.Abstractions\bin\Release\netstandard1.0\Plugin.Calendars.Abstractions.dll" target="lib\UAP10\Plugin.Calendars.Abstractions.dll" />
      <file src="Calendars\Calendars.Plugin.Abstractions\bin\Release\netstandard1.0\Plugin.Calendars.Abstractions.xml" target="lib\UAP10\Plugin.Calendars.Abstractions.xml" />
      <file src="Calendars\Calendars.Plugin.Abstractions\bin\Release\netstandard1.0\Plugin.Calendars.Abstractions.pdb" target="lib\UAP10\Plugin.Calendars.Abstractions.pdb" />

--- a/Calendars.nuspec
+++ b/Calendars.nuspec
@@ -8,9 +8,8 @@
        <owners>Caleb Clarke</owners>
        <licenseUrl>https://github.com/TheAlmightyBob/Calendars/blob/master/LICENSE</licenseUrl>
        <projectUrl>https://github.com/TheAlmightyBob/Calendars</projectUrl>
-     <!--Default Icon, a template can be found:  https://raw.githubusercontent.com/jamesmontemagno/Xamarin-Templates/master/Plugins-Templates/icons/plugin_icon.png-->  
-     <iconUrl>https://raw.githubusercontent.com/jamesmontemagno/Xamarin-Templates/master/Plugins-Templates/icons/plugin_icon_nuget.png</iconUrl>
-     
+       <!--Default Icon, a template can be found:  https://raw.githubusercontent.com/jamesmontemagno/Xamarin-Templates/master/Plugins-Templates/icons/plugin_icon.png-->  
+       <iconUrl>https://raw.githubusercontent.com/jamesmontemagno/Xamarin-Templates/master/Plugins-Templates/icons/plugin_icon_nuget.png</iconUrl>
        <requireLicenseAcceptance>false</requireLicenseAcceptance>
        <description>
          Perform basic CRUD calendar operations on iOS/Android/WinPhone/UWP through a simple common API.
@@ -56,8 +55,9 @@ Android all-day events are no longer affected by timezone.
 
      <!--Universal Windows Platform-->
      <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.dll" target="lib\UAP10\Plugin.Calendars.dll" />
-     <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.pdb" target="lib\UAP10\Plugin.Calendars.pdb" />
      <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.xml" target="lib\UAP10\Plugin.Calendars.xml" />
+     <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Plugin.Calendars.pdb" target="lib\UAP10\Plugin.Calendars.pdb" />
+     <file src="Calendars\Calendars.Plugin.UWP\bin\Release\Properties\Calendars.Plugin.UWP.rd.xml" target="lib\UAP10\Calendars.Plugin.UWP\Properties" />
      <file src="Calendars\Calendars.Plugin.Abstractions\bin\Release\netstandard1.0\Plugin.Calendars.Abstractions.dll" target="lib\UAP10\Plugin.Calendars.Abstractions.dll" />
      <file src="Calendars\Calendars.Plugin.Abstractions\bin\Release\netstandard1.0\Plugin.Calendars.Abstractions.xml" target="lib\UAP10\Plugin.Calendars.Abstractions.xml" />
      <file src="Calendars\Calendars.Plugin.Abstractions\bin\Release\netstandard1.0\Plugin.Calendars.Abstractions.pdb" target="lib\UAP10\Plugin.Calendars.Abstractions.pdb" />

--- a/Calendars/Calendars.Plugin.UWP/Calendars.Plugin.UWP.csproj
+++ b/Calendars/Calendars.Plugin.UWP/Calendars.Plugin.UWP.csproj
@@ -84,6 +84,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <DocumentationFile>bin\x64\Release\Plugin.Calendars.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -124,7 +125,9 @@
     <Compile Include="IAsyncActionExtensions.cs" />
     <Compile Include="IAsyncOperationExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Content Include="Properties\Calendars.Plugin.UWP.rd.xml" />
+    <EmbeddedResource Include="Properties\Calendars.Plugin.UWP.rd.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calendars.Plugin.Abstractions\Calendars.Plugin.Abstractions.csproj">


### PR DESCRIPTION
also small indent thing and changed the order of xml and pdb so that it is everywhere the same order. And added the almost empty xml which was mentioned in the sample for an xamarin form plugin template. More info can be found at #50 