### PR TITLE
Fixing Android CI

### DIFF
--- a/CI/install-android-sdk.ps1
+++ b/CI/install-android-sdk.ps1
@@ -1,4 +1,4 @@
 $AndroidToolPath = "${env:ProgramFiles(x86)}\Android\android-sdk\tools\android" 
 #$AndroidToolPath = "$env:localappdata\Android\android-sdk\tools\android"
 
-echo 'y' | & $AndroidToolPath update sdk -u -a -t android-15
+echo 'y' | & $AndroidToolPath update sdk -u -a -t android-15 --use-sdk-wrapper


### PR DESCRIPTION
Add --use-sdk-wrapper to bypass warning about using the "android" command, which was swallowing our scripted "yes" that was intended to accept the license agreement.