### PR TITLE
Net standard versioning

### DIFF
--- a/Calendars/Calendars.Plugin.Abstractions/Calendars.Plugin.Abstractions.csproj
+++ b/Calendars/Calendars.Plugin.Abstractions/Calendars.Plugin.Abstractions.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Plugin.Calendars.Abstractions</AssemblyName>
     <RootNamespace>Plugin.Calendars.Abstractions</RootNamespace>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
+    <Version>1.0.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Calendars/Calendars.Plugin.Abstractions/Calendars.Plugin.Abstractions.csproj
+++ b/Calendars/Calendars.Plugin.Abstractions/Calendars.Plugin.Abstractions.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Plugin.Calendars.Abstractions</AssemblyName>
     <RootNamespace>Plugin.Calendars.Abstractions</RootNamespace>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0.0</Version>
   </PropertyGroup>
 

--- a/Calendars/Calendars.Plugin/Calendars.Plugin.csproj
+++ b/Calendars/Calendars.Plugin/Calendars.Plugin.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Plugin.Calendars</AssemblyName>
     <RootNamespace>Plugin.Calendars</RootNamespace>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
+    <Version>1.0.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Calendars/Calendars.Plugin/Calendars.Plugin.csproj
+++ b/Calendars/Calendars.Plugin/Calendars.Plugin.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Plugin.Calendars</AssemblyName>
     <RootNamespace>Plugin.Calendars</RootNamespace>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0.0</Version>
   </PropertyGroup>
 


### PR DESCRIPTION
Added `Version` placeholders to the .NET Standard csproj files so that it can be filled in by AppVeyor.