### PR TITLE
Reminders

### DIFF
--- a/Calendars/Calendars.Plugin.Abstractions/CalendarEvent.cs
+++ b/Calendars/Calendars.Plugin.Abstractions/CalendarEvent.cs
@@ -43,6 +43,12 @@ namespace Plugin.Calendars.Abstractions
         public string Description { get; set; }
 
         /// <summary>
+        /// Event reminders
+        /// </summary>
+        /// <remarks>Windows only supports a single reminder</remarks>
+        public IList<CalendarEventReminder> Reminders { get; set; }
+
+        /// <summary>
         /// Platform-specific unique calendar event identifier
         /// </summary>
         /// <remarks>This ID will be the same for each instance of a recurring event.</remarks>

--- a/Calendars/Calendars.Plugin.Abstractions/CalendarEventReminder.cs
+++ b/Calendars/Calendars.Plugin.Abstractions/CalendarEventReminder.cs
@@ -21,6 +21,26 @@ namespace Plugin.Calendars.Abstractions
         /// Type of reminder to display on Android. (not used by Windows/iOS)
         /// </summary>
         public CalendarReminderMethod Method { get; set; } = CalendarReminderMethod.Default;
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj is CalendarEventReminder other)
+            {
+                return TimeBefore == other.TimeBefore &&
+                    Method == other.Method;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return Tuple.Create(TimeBefore, Method).GetHashCode();
+        }
     }
 
     /// <summary>

--- a/Calendars/Calendars.Plugin.Abstractions/ICalendars.cs
+++ b/Calendars/Calendars.Plugin.Abstractions/ICalendars.cs
@@ -64,10 +64,12 @@ namespace Plugin.Calendars.Abstractions
         /// Add new event to a calendar or update an existing event.
         /// If a new event was added, the ExternalID property will be set on the CalendarEvent object,
         /// to support future queries/updates.
+        /// Note that UWP does not allow adding multiple reminders to an event.
         /// </summary>
         /// <param name="calendar">Destination calendar</param>
         /// <param name="calendarEvent">Event to add or update</param>
         /// <exception cref="System.ArgumentException">Calendar is not specified, does not exist on device, or is read-only</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">Windows does not support multiple reminders</exception>
         /// <exception cref="System.UnauthorizedAccessException">Calendar access denied</exception>
         /// <exception cref="System.InvalidOperationException">Editing recurring events is not supported</exception>
         /// <exception cref="Plugin.Calendars.Abstractions.PlatformException">Unexpected platform-specific error</exception>
@@ -105,6 +107,7 @@ namespace Plugin.Calendars.Abstractions
         /// <exception cref="ArgumentException">Calendar event is not created or not valid</exception>
         /// <exception cref="System.InvalidOperationException">Editing recurring events is not supported</exception>
         /// <exception cref="Plugin.Calendars.Abstractions.PlatformException">Unexpected platform-specific error</exception>
+        [Obsolete("Please use AddOrUpdateEventAsync to update reminders for an event")]
         Task AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder);
     }
 }

--- a/Calendars/Calendars.Plugin.Abstractions/ICalendars.cs
+++ b/Calendars/Calendars.Plugin.Abstractions/ICalendars.cs
@@ -102,10 +102,9 @@ namespace Plugin.Calendars.Abstractions
         /// </summary>
         /// <param name="calendarEvent">Event to add</param>
         /// <param name="reminder">Reminder to add</param>
-        /// <returns>If successful</returns>
         /// <exception cref="ArgumentException">Calendar event is not created or not valid</exception>
         /// <exception cref="System.InvalidOperationException">Editing recurring events is not supported</exception>
         /// <exception cref="Plugin.Calendars.Abstractions.PlatformException">Unexpected platform-specific error</exception>
-        Task<bool> AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder);
+        Task AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder);
     }
 }

--- a/Calendars/Calendars.Plugin.Android/CalendarEventReminderExtensions.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarEventReminderExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Android.Content;
+using Android.Provider;
+using Plugin.Calendars.Abstractions;
+
+namespace Plugin.Calendars
+{
+    public static class CalendarEventReminderExtensions
+    {
+        public static ContentValues ToContentValues(this CalendarEventReminder reminder, string eventID)
+        {
+            var reminderValues = new ContentValues();
+            reminderValues.Put(CalendarContract.Reminders.InterfaceConsts.Minutes, reminder.TimeBefore.TotalMinutes);
+            reminderValues.Put(CalendarContract.Reminders.InterfaceConsts.EventId, eventID);
+            reminderValues.Put(CalendarContract.Reminders.InterfaceConsts.Method, (int)reminder.Method.ToRemindersMethod());
+
+            return reminderValues;
+        }
+    }
+}

--- a/Calendars/Calendars.Plugin.Android/CalendarEventReminderExtensions.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarEventReminderExtensions.cs
@@ -6,12 +6,16 @@ namespace Plugin.Calendars
 {
     public static class CalendarEventReminderExtensions
     {
-        public static ContentValues ToContentValues(this CalendarEventReminder reminder, string eventID)
+        public static ContentValues ToContentValues(this CalendarEventReminder reminder, string eventID = null)
         {
             var reminderValues = new ContentValues();
             reminderValues.Put(CalendarContract.Reminders.InterfaceConsts.Minutes, reminder.TimeBefore.TotalMinutes);
-            reminderValues.Put(CalendarContract.Reminders.InterfaceConsts.EventId, eventID);
             reminderValues.Put(CalendarContract.Reminders.InterfaceConsts.Method, (int)reminder.Method.ToRemindersMethod());
+
+            if (!string.IsNullOrWhiteSpace(eventID))
+            {
+                reminderValues.Put(CalendarContract.Reminders.InterfaceConsts.EventId, eventID);
+            }
 
             return reminderValues;
         }

--- a/Calendars/Calendars.Plugin.Android/Calendars.Plugin.Android.csproj
+++ b/Calendars/Calendars.Plugin.Android/Calendars.Plugin.Android.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\Calendars.Plugin\CrossCalendars.cs">
       <Link>CrossCalendars.cs</Link>
     </Compile>
+    <Compile Include="CalendarEventReminderExtensions.cs" />
     <Compile Include="CalendarsImplementation.cs" />
     <Compile Include="ReminderMethodExtensions.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />

--- a/Calendars/Calendars.Plugin.Android/Calendars.Plugin.Android.csproj
+++ b/Calendars/Calendars.Plugin.Android/Calendars.Plugin.Android.csproj
@@ -49,6 +49,7 @@
       <Link>CrossCalendars.cs</Link>
     </Compile>
     <Compile Include="CalendarsImplementation.cs" />
+    <Compile Include="ReminderMethodExtensions.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CursorExtensions.cs" />

--- a/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
@@ -449,8 +449,6 @@ namespace Plugin.Calendars
         /// <exception cref="Plugin.Calendars.Abstractions.PlatformException">Unexpected platform-specific error</exception>
         public async Task AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder)
         {
-            // TODO: Why does this return a bool? It never returns false. Just "true" or throws.
-
             if (string.IsNullOrEmpty(calendarEvent.ExternalID))
             {
                 throw new ArgumentException("Missing calendar event identifier", "calendarEvent");

--- a/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
@@ -210,7 +210,7 @@ namespace Plugin.Calendars
                                 Location = cursor.GetString(CalendarContract.Events.InterfaceConsts.EventLocation),
                                 AllDay = allDay
                             };
-                            calendarEvent.Reminders = GetEventReminders(calendarEvent);
+                            calendarEvent.Reminders = GetEventReminders(calendarEvent.ExternalID);
 
                             events.Add(calendarEvent);
                         } while (cursor.MoveToNext());
@@ -687,7 +687,7 @@ namespace Plugin.Calendars
                         AllDay = allDay
                     };
 
-                    calendarEvent.Reminders = GetEventReminders(calendarEvent);
+                    calendarEvent.Reminders = GetEventReminders(calendarEvent.ExternalID);
                 }
             }
             catch (Java.Lang.Exception ex)
@@ -706,16 +706,13 @@ namespace Plugin.Calendars
         /// Get reminders for an event.
         /// Assumes that event existence/validity has already been verified.
         /// </summary>
-        /// <param name="calendarEvent">Event for which to retrieve reminders</param>
+        /// <param name="eventID">Event ID for which to retrieve reminders</param>
         /// <returns>Reminders</returns>
-        private IList<CalendarEventReminder> GetEventReminders(CalendarEvent calendarEvent)
+        private IList<CalendarEventReminder> GetEventReminders(string eventID)
         {
-            // TODO: Probably should just take external ID as a parameter rather than a CalendarEvent,
-            //       since this is used to populate a CalendarEvent?
-
-            if (string.IsNullOrEmpty(calendarEvent.ExternalID))
+            if (string.IsNullOrEmpty(eventID))
             {
-                throw new ArgumentException("Missing calendar event identifier", "calendarEvent");
+                throw new ArgumentException("Missing calendar event identifier", "eventID");
             }
 
             // Not bothering to verify that event exists because this is intended for internal use
@@ -730,7 +727,7 @@ namespace Plugin.Calendars
             var reminders = new List<CalendarEventReminder>();
 
             var cursor = Query(CalendarContract.Reminders.ContentUri, remindersProjection,
-                $"{CalendarContract.Reminders.InterfaceConsts.EventId} = {calendarEvent.ExternalID}",
+                $"{CalendarContract.Reminders.InterfaceConsts.EventId} = {eventID}",
                 null, null);
 
             // TODO: Couldn't we use an IterateCursor<T> helper that handles all the MoveToFirst/try/catch/MoveToNext/Close boilerplate

--- a/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
@@ -702,6 +702,12 @@ namespace Plugin.Calendars
             return calendarEvent;
         }
 
+        /// <summary>
+        /// Get reminders for an event.
+        /// Assumes that event existence/validity has already been verified.
+        /// </summary>
+        /// <param name="calendarEvent">Event for which to retrieve reminders</param>
+        /// <returns>Reminders</returns>
         private IList<CalendarEventReminder> GetEventReminders(CalendarEvent calendarEvent)
         {
             // TODO: Probably should just take external ID as a parameter rather than a CalendarEvent,
@@ -755,7 +761,16 @@ namespace Plugin.Calendars
             return reminders.Count > 0 ? reminders : null;
         }
 
-        private IList<ContentProviderOperation> BuildReminderUpdateOperations(IList<CalendarEventReminder> reminders, CalendarEvent existingEvent)
+        /// <summary>
+        /// Builds ContentProviderOperations for adding/removing reminders.
+        /// Specifically intended for use by AddOrUpdateEvent, as if existingEvent is omitted,
+        /// this requires that the operations are added to a batch in which the first operation
+        /// inserts the event.
+        /// </summary>
+        /// <param name="reminders">New reminders (replacing existing reminders, if any)</param>
+        /// <param name="existingEvent">(optional) Existing event to update reminders for</param>
+        /// <returns>List of ContentProviderOperations for applying reminder updates as part of a batched update</returns>
+        private IList<ContentProviderOperation> BuildReminderUpdateOperations(IList<CalendarEventReminder> reminders, CalendarEvent existingEvent = null)
         {
             var operations = new List<ContentProviderOperation>();
 

--- a/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
@@ -444,11 +444,10 @@ namespace Plugin.Calendars
         /// </summary>
         /// <param name="calendarEvent">Event to add the reminder to</param>
         /// <param name="reminder">The reminder</param>
-        /// <returns>If successful</returns>
         /// <exception cref="ArgumentException">Calendar event is not created or not valid</exception>
         /// <exception cref="System.InvalidOperationException">Editing recurring events is not supported</exception>
         /// <exception cref="Plugin.Calendars.Abstractions.PlatformException">Unexpected platform-specific error</exception>
-        public async Task<bool> AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder)
+        public async Task AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder)
         {
             // TODO: Why does this return a bool? It never returns false. Just "true" or throws.
 
@@ -465,7 +464,7 @@ namespace Plugin.Calendars
                 throw new ArgumentException("Specified calendar event not found on device");
             }
             
-            return await Task.Run(() =>
+            await Task.Run(() =>
             {
                 if (IsEventRecurring(calendarEvent.ExternalID))
                 {
@@ -473,8 +472,6 @@ namespace Plugin.Calendars
                 }
 
                 Insert(_remindersUri, reminder.ToContentValues(calendarEvent.ExternalID));
-
-                return true;
             }).ConfigureAwait(false);
         }
 

--- a/Calendars/Calendars.Plugin.Android/ReminderMethodExtensions.cs
+++ b/Calendars/Calendars.Plugin.Android/ReminderMethodExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Android.Provider;
+using Plugin.Calendars.Abstractions;
+
+namespace Plugin.Calendars
+{
+    static class ReminderMethodExtensions
+    {
+        static public RemindersMethod ToRemindersMethod(this CalendarReminderMethod method)
+        {
+            switch (method)
+            {
+                case CalendarReminderMethod.Alert:
+                    return RemindersMethod.Alert;
+
+                case CalendarReminderMethod.Default:
+                    return RemindersMethod.Default;
+
+                case CalendarReminderMethod.Email:
+                    return RemindersMethod.Email;
+
+                case CalendarReminderMethod.Sms:
+                    return RemindersMethod.Sms;
+
+                default:
+                    throw new ArgumentException("Unexpected reminder method", nameof(method));
+            }
+        }
+
+        static public CalendarReminderMethod ToCalendarReminderMethod(this RemindersMethod method)
+        {
+            switch (method)
+            {
+                case RemindersMethod.Alert:
+                    return CalendarReminderMethod.Alert;
+
+                case RemindersMethod.Default:
+                    return CalendarReminderMethod.Default;
+
+                case RemindersMethod.Email:
+                    return CalendarReminderMethod.Email;
+
+                case RemindersMethod.Sms:
+                    return CalendarReminderMethod.Sms;
+
+                default:
+                    throw new ArgumentException("Unexpected reminders method", nameof(method));
+            }
+        }
+    }
+}

--- a/Calendars/Calendars.Plugin.UWP/AppointmentExtensions.cs
+++ b/Calendars/Calendars.Plugin.UWP/AppointmentExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Plugin.Calendars.Abstractions;
+using System.Collections.Generic;
 using Windows.ApplicationModel.Appointments;
 
 namespace Plugin.Calendars
@@ -15,6 +16,8 @@ namespace Plugin.Calendars
         /// <returns>Corresponding Calendars.Plugin.Abstractions.CalendarEvent</returns>
         public static CalendarEvent ToCalendarEvent(this Appointment appt)
         {
+            var reminder = appt.Reminder.HasValue ? new CalendarEventReminder { TimeBefore = appt.Reminder.Value } : null;
+
             return new CalendarEvent
             {
                 Name = appt.Subject,
@@ -23,7 +26,8 @@ namespace Plugin.Calendars
                 End = appt.StartTime.Add(appt.Duration).LocalDateTime,
                 AllDay = appt.AllDay,
                 Location = appt.Location,
-                ExternalID = appt.LocalId
+                ExternalID = appt.LocalId,
+                Reminders = reminder != null ? new List<CalendarEventReminder> { reminder } : null
             };
         }
     }

--- a/Calendars/Calendars.Plugin.UWP/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.UWP/CalendarsImplementation.cs
@@ -290,7 +290,7 @@ namespace Plugin.Calendars
                 throw new ArgumentException("Event does not have a valid calendar.");
             }
 
-            existingAppt.Reminder = reminder?.TimeBefore ?? TimeSpan.FromMinutes(15);
+            existingAppt.Reminder = reminder.TimeBefore;
             
             await appCalendar.SaveAppointmentAsync(existingAppt);
         }

--- a/Calendars/Calendars.Plugin.UWP/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.UWP/CalendarsImplementation.cs
@@ -259,11 +259,10 @@ namespace Plugin.Calendars
         /// </summary>
         /// <param name="calendarEvent">Event to add the reminder to</param>
         /// <param name="reminder">The reminder</param>
-        /// <returns>If successful</returns>
         /// <exception cref="ArgumentException">Calendar event is not created or not valid</exception>
         /// <exception cref="System.InvalidOperationException">Editing recurring events is not supported</exception>
         /// <exception cref="Plugin.Calendars.Abstractions.PlatformException">Unexpected platform-specific error</exception>
-        public async Task<bool> AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder)
+        public async Task AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder)
         {
             if (string.IsNullOrEmpty(calendarEvent.ExternalID))
             {
@@ -294,8 +293,6 @@ namespace Plugin.Calendars
             existingAppt.Reminder = reminder?.TimeBefore ?? TimeSpan.FromMinutes(15);
             
             await appCalendar.SaveAppointmentAsync(existingAppt);
-
-            return true;
         }
 
         /// <summary>

--- a/Calendars/Calendars.Plugin.iOSUnified/CalendarEventReminderExtensions.cs
+++ b/Calendars/Calendars.Plugin.iOSUnified/CalendarEventReminderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using EventKit;
+using Plugin.Calendars.Abstractions;
+
+namespace Plugin.Calendars
+{
+    public static class CalendarEventReminderExtensions
+    {
+        public static EKAlarm ToEKAlarm(this CalendarEventReminder calendarEventReminder)
+        {
+            // iOS stores in negative seconds before the event, but CalendarEventReminder.TimeBefore uses
+            // a positive TimeSpan before the event
+            var seconds = -calendarEventReminder.TimeBefore.TotalSeconds;
+            return EKAlarm.FromTimeInterval(seconds); 
+        }
+    }
+}

--- a/Calendars/Calendars.Plugin.iOSUnified/Calendars.Plugin.iOSUnified.csproj
+++ b/Calendars/Calendars.Plugin.iOSUnified/Calendars.Plugin.iOSUnified.csproj
@@ -36,9 +36,11 @@
     <Compile Include="..\Calendars.Plugin\CrossCalendars.cs">
       <Link>CrossCalendars.cs</Link>
     </Compile>
+    <Compile Include="CalendarEventReminderExtensions.cs" />
     <Compile Include="CalendarsImplementation.cs" />
     <Compile Include="ColorConversion.cs" />
     <Compile Include="DateConversionExtensions.cs" />
+    <Compile Include="EKAlarmExtensions.cs" />
     <Compile Include="EKCalendarExtensions.cs" />
     <Compile Include="EKEventExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -54,6 +56,9 @@
       <Project>{ae8e6fff-da18-4ecb-b0b0-abc527b5de32}</Project>
       <Name>Calendars.Plugin.Abstractions</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Calendars/Calendars.Plugin.iOSUnified/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.iOSUnified/CalendarsImplementation.cs
@@ -301,11 +301,10 @@ namespace Plugin.Calendars
         /// </summary>
         /// <param name="calendarEvent">Event to add the reminder to</param>
         /// <param name="reminder">The reminder</param>
-        /// <returns>If successful</returns>
         /// <exception cref="ArgumentException">Calendar event is not created or not valid</exception>
         /// <exception cref="System.InvalidOperationException">Editing recurring events is not supported</exception>
         /// <exception cref="Plugin.Calendars.Abstractions.PlatformException">Unexpected platform-specific error</exception>
-        public async Task<bool> AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder)
+        public async Task AddEventReminderAsync(CalendarEvent calendarEvent, CalendarEventReminder reminder)
         {
             if (string.IsNullOrEmpty(calendarEvent.ExternalID))
             {
@@ -344,8 +343,6 @@ namespace Plugin.Calendars
 
                 throw new ArgumentException(error.LocalizedDescription, nameof(reminder), new NSErrorException(error));
             }
-
-            return true;
         }
 
         /// <summary>

--- a/Calendars/Calendars.Plugin.iOSUnified/EKAlarmExtensions.cs
+++ b/Calendars/Calendars.Plugin.iOSUnified/EKAlarmExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using EventKit;
+using Plugin.Calendars.Abstractions;
+
+namespace Plugin.Calendars
+{
+    public static class EKAlarmExtensions
+    {
+        public static CalendarEventReminder ToCalendarEventReminder(this EKAlarm alarm)
+        {
+            return new CalendarEventReminder
+            {
+                // iOS stores in negative seconds before the event, but CalendarEventReminder.TimeBefore uses
+                // a positive TimeSpan before the event
+                TimeBefore = -TimeSpan.FromSeconds(alarm.RelativeOffset)
+            };
+        }
+    }
+}

--- a/Calendars/Calendars.Plugin.iOSUnified/EKEventExtensions.cs
+++ b/Calendars/Calendars.Plugin.iOSUnified/EKEventExtensions.cs
@@ -1,6 +1,6 @@
-using Plugin.Calendars.Abstractions;
-
 using EventKit;
+using Plugin.Calendars.Abstractions;
+using System.Linq;
 
 namespace Plugin.Calendars
 {
@@ -17,19 +17,20 @@ namespace Plugin.Calendars
         public static CalendarEvent ToCalendarEvent(this EKEvent ekEvent)
         {
             return new CalendarEvent
-                {
-                    Name = ekEvent.Title,
-                    Description = ekEvent.Notes,
-                    Start = ekEvent.StartDate.ToDateTime(),
+            {
+                Name = ekEvent.Title,
+                Description = ekEvent.Notes,
+                Start = ekEvent.StartDate.ToDateTime(),
 
-                    // EventKit treats a one-day AllDay event as starting/ending on the same day,
-                    // but WinPhone/Android (and thus Calendars.Plugin) define it as ending on the following day.
-                    //
-                    End = ekEvent.EndDate.ToDateTime().AddSeconds(ekEvent.AllDay ? 1 : 0),
-                    AllDay = ekEvent.AllDay,
-                    Location = ekEvent.Location,
-                    ExternalID = ekEvent.EventIdentifier
-                };
+                // EventKit treats a one-day AllDay event as starting/ending on the same day,
+                // but WinPhone/Android (and thus Calendars.Plugin) define it as ending on the following day.
+                //
+                End = ekEvent.EndDate.ToDateTime().AddSeconds(ekEvent.AllDay ? 1 : 0),
+                AllDay = ekEvent.AllDay,
+                Location = ekEvent.Location,
+                ExternalID = ekEvent.EventIdentifier,
+                Reminders = ekEvent.Alarms?.Select(alarm => alarm.ToCalendarEventReminder()).ToList()
+            };
         }
     }
 }

--- a/Calendars/Calendars.Plugin.iOSUnified/packages.config
+++ b/Calendars/Calendars.Plugin.iOSUnified/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinios10" />
+</packages>

--- a/Tests/Calendars.Plugin.UWP.Tests/CalendarTests.cs
+++ b/Tests/Calendars.Plugin.UWP.Tests/CalendarTests.cs
@@ -469,6 +469,25 @@ namespace Plugin.Calendars.UWP.Tests
         }
 
         [TestMethod, TestCategory(_testCategory)]
+        public async Task Calendars_AddEventReminder_ReplacesExistingReminder()
+        {
+            var calendarEvent = GetTestEvent();
+            var firstReminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(42) };
+            var secondReminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(5) };
+            var calendar = await _service.CreateCalendarAsync(_calendarName);
+
+            calendarEvent.Reminders = new List<CalendarEventReminder> { firstReminder };
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            await _service.AddEventReminderAsync(calendarEvent, secondReminder);
+
+            var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
+
+            Assert.AreEqual(secondReminder, eventFromId.Reminders.Single());
+        }
+
+        [TestMethod, TestCategory(_testCategory)]
         public async Task Calendars_GetEvents_NonexistentCalendarThrows()
         {
             var calendar = new Calendar { Name = "Bob", ExternalID = "42" };

--- a/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
+++ b/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
@@ -404,6 +404,42 @@ namespace Plugin.Calendars.Android.Tests
         }
 
         [Test]
+        public async void Calendars_AddOrUpdateEvents_NewEventWithReminder()
+        {
+            var calendarEvent = GetTestEvent();
+            var reminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(42) };
+            var calendar = await _service.CreateCalendarAsync(_calendarName);
+
+            calendarEvent.Reminders = new List<CalendarEventReminder> { reminder };
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
+
+            Assert.AreEqual(reminder, eventFromId.Reminders.Single());
+        }
+
+        [Test]
+        public async void Calendars_AddOrUpdateEvents_NewEventMultipleReminders()
+        {
+            var calendarEvent = GetTestEvent();
+            var reminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(42) };
+            var calendar = await _service.CreateCalendarAsync(_calendarName);
+
+            calendarEvent.Reminders = new List<CalendarEventReminder>
+            {
+                new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(42) },
+                new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(10) },
+            };
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
+
+            Assert.AreEqual(calendarEvent.Reminders, eventFromId.Reminders);
+        }
+
+        [Test]
         public async void Calendars_AddOrUpdateEvents_ExistingEventEditsReminder()
         {
             var calendarEvent = GetTestEvent();
@@ -420,7 +456,7 @@ namespace Plugin.Calendars.Android.Tests
 
             var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
 
-            Assert.AreEqual(firstReminder.TimeBefore, eventFromId.Reminders.Single().TimeBefore);
+            Assert.AreEqual(firstReminder, eventFromId.Reminders.Single());
 
             // Change reminder on event
             calendarEvent.Reminders = new List<CalendarEventReminder> { secondReminder };
@@ -429,7 +465,7 @@ namespace Plugin.Calendars.Android.Tests
 
             eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
 
-            Assert.AreEqual(secondReminder.TimeBefore, eventFromId.Reminders.Single().TimeBefore);
+            Assert.AreEqual(secondReminder, eventFromId.Reminders.Single());
 
             // Remove reminder from event
             calendarEvent.Reminders = new List<CalendarEventReminder>();
@@ -454,8 +490,7 @@ namespace Plugin.Calendars.Android.Tests
 
             var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
 
-            Assert.AreEqual(1, eventFromId.Reminders.Count);
-            Assert.AreEqual(reminder.TimeBefore, eventFromId.Reminders.First().TimeBefore);
+            Assert.AreEqual(reminder, eventFromId.Reminders.Single());
         }
 
 #if !__IOS__ // Reminder methods are Android-specific
@@ -472,9 +507,8 @@ namespace Plugin.Calendars.Android.Tests
             await _service.AddEventReminderAsync(calendarEvent, reminder);
 
             var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
-            
-            Assert.AreEqual(reminder.TimeBefore, eventFromId.Reminders.Single().TimeBefore);
-            Assert.AreEqual(reminderMethod, eventFromId.Reminders.Single().Method);
+
+            Assert.AreEqual(reminder, eventFromId.Reminders.Single());
         }
 #endif
 

--- a/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
+++ b/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
@@ -404,6 +404,44 @@ namespace Plugin.Calendars.Android.Tests
         }
 
         [Test]
+        public async void Calendars_AddOrUpdateEvents_ExistingEventEditsReminder()
+        {
+            var calendarEvent = GetTestEvent();
+            var firstReminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(42) };
+            var secondReminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(5) };
+            var calendar = await _service.CreateCalendarAsync(_calendarName);
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            // Add reminder to event
+            calendarEvent.Reminders = new List<CalendarEventReminder> { firstReminder };
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
+
+            Assert.AreEqual(firstReminder.TimeBefore, eventFromId.Reminders.Single().TimeBefore);
+
+            // Change reminder on event
+            calendarEvent.Reminders = new List<CalendarEventReminder> { secondReminder };
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
+
+            Assert.AreEqual(secondReminder.TimeBefore, eventFromId.Reminders.Single().TimeBefore);
+
+            // Remove reminder from event
+            calendarEvent.Reminders = new List<CalendarEventReminder>();
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
+
+            Assert.IsNull(eventFromId.Reminders);
+        }
+
+        [Test]
         public async void Calendars_AddEventReminder_AddsReminder()
         {
             var calendarEvent = GetTestEvent();

--- a/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
+++ b/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
@@ -478,7 +478,7 @@ namespace Plugin.Calendars.Android.Tests
         }
 
         [Test]
-        public async void Calendars_AddEventReminder_AddsReminder()
+        public async void Calendars_AddEventReminder_SetsSingleReminderIfNone()
         {
             var calendarEvent = GetTestEvent();
             var reminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(42) };
@@ -491,6 +491,25 @@ namespace Plugin.Calendars.Android.Tests
             var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
 
             Assert.AreEqual(reminder, eventFromId.Reminders.Single());
+        }
+
+        [Test]
+        public async void Calendars_AddEventReminder_AddsMoreReminders()
+        {
+            var calendarEvent = GetTestEvent();
+            var firstReminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(42) };
+            var secondReminder = new CalendarEventReminder { TimeBefore = TimeSpan.FromMinutes(5) };
+            var calendar = await _service.CreateCalendarAsync(_calendarName);
+
+            calendarEvent.Reminders = new List<CalendarEventReminder> { firstReminder };
+
+            await _service.AddOrUpdateEventAsync(calendar, calendarEvent);
+
+            await _service.AddEventReminderAsync(calendarEvent, secondReminder);
+
+            var eventFromId = await _service.GetEventByIdAsync(calendarEvent.ExternalID);
+
+            Assert.AreEqual(new List<CalendarEventReminder> { firstReminder, secondReminder }, eventFromId.Reminders);
         }
 
 #if !__IOS__ // Reminder methods are Android-specific


### PR DESCRIPTION
Resolves #2 

Reminders are now retrieved/updated as part of `CalendarEvent`.

`AddEventReminderAsync` still works (and now has tests) but is deprecated in favor of just using `AddOrUpdateEventAsync` to add/remove/modify reminders. It also no longer returns a `bool` and no longer considers the `reminder` argument optional (small breaking change... it never returned anything but `true` and a new `CalendarEventReminder` has the same default values as were used if `null` was provided).

Also some extra general refactoring, especially on Android.