### PR TITLE
Set AllDay value as an integer instead of a boolean

### DIFF
--- a/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
@@ -354,7 +354,7 @@ namespace Plugin.Calendars
                     eventValues.Put(CalendarContract.Events.InterfaceConsts.Dtend,
                         DateConversions.GetDateAsAndroidMS(end));
                     eventValues.Put(CalendarContract.Events.InterfaceConsts.AllDay,
-                        allDay);
+                                    allDay ? 1 : 0);
                     eventValues.Put(CalendarContract.Events.InterfaceConsts.EventLocation,
                         calendarEvent.Location ?? string.Empty);
 


### PR DESCRIPTION
Fixes #18 

Yep. I can't believe this was the problem, after all this time. Seems like setting AllDay to "true" worked in some places (e.g. the Google Calendar app event editor) but not others (e.g. the multi-day calendar view). Simply setting it to "1" instead seems to behave as expected everywhere.