### PR TITLE
Reuse a single instance of CalendarsImplementation for iOS tests

### DIFF
--- a/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
+++ b/Tests/Calendars.Plugin.iOSUnified.Tests/CalendarTests.cs
@@ -35,7 +35,14 @@ namespace Plugin.Calendars.Android.Tests
         [SetUp]
         public void Setup()
         {
+            // iOS won't let us keep recreating the event store
+            // (gives the error
+            //  "[EventKit] Client tried to open too many connections to calaccessd. Refusing to open another")
+#if __IOS__
+            _service ??= new CalendarsImplementation();
+#else
             _service = new CalendarsImplementation();
+#endif
 
             // Android supports milliseconds, iOS supports seconds
 #if __IOS__

--- a/Tests/Calendars.Plugin.iOSUnified.Tests/Calendars.Plugin.iOSUnified.Tests.csproj
+++ b/Tests/Calendars.Plugin.iOSUnified.Tests/Calendars.Plugin.iOSUnified.Tests.csproj
@@ -25,6 +25,7 @@
     <CodesignEntitlements>
     </CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
+<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -38,6 +39,7 @@
     <CodesignEntitlements>
     </CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
+<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,6 +54,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -63,6 +66,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>none</DebugType>
@@ -76,6 +80,7 @@
     <BuildIpa>True</BuildIpa>
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>none</DebugType>
@@ -88,6 +93,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />


### PR DESCRIPTION
iOS doesn't like us creating multiple event stores (and since the library is already intended to be used as a singleton in real apps, it seems more appropriate to just change the test)