### PR TITLE
Treat null reminders as "ignore reminders" rather than "no reminders."

### DIFF
--- a/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.Android/CalendarsImplementation.cs
@@ -640,7 +640,7 @@ namespace Plugin.Calendars
                 Method = ((RemindersMethod)cursor.GetInt(CalendarContract.Reminders.InterfaceConsts.Method)).ToCalendarReminderMethod()
             });
 
-            return reminders.Count > 0 ? reminders : null;
+            return reminders;
         }
 
         /// <summary>
@@ -656,10 +656,10 @@ namespace Plugin.Calendars
         {
             var operations = new List<ContentProviderOperation>();
 
-            // If reminders haven't changed, do nothing
+            // If reminders are null or haven't changed, do nothing
             //
-            if (reminders == existingEvent?.Reminders ||
-                (reminders != null && existingEvent?.Reminders != null && reminders.SequenceEqual(existingEvent.Reminders)))
+            if (reminders == null ||
+                (existingEvent?.Reminders != null && reminders.SequenceEqual(existingEvent.Reminders)))
             {
                 return operations;
             }

--- a/Calendars/Calendars.Plugin.UWP/AppointmentExtensions.cs
+++ b/Calendars/Calendars.Plugin.UWP/AppointmentExtensions.cs
@@ -27,7 +27,7 @@ namespace Plugin.Calendars
                 AllDay = appt.AllDay,
                 Location = appt.Location,
                 ExternalID = appt.LocalId,
-                Reminders = reminder != null ? new List<CalendarEventReminder> { reminder } : null
+                Reminders = reminder != null ? new List<CalendarEventReminder> { reminder } : new List<CalendarEventReminder>()
             };
         }
     }

--- a/Calendars/Calendars.Plugin.UWP/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.UWP/CalendarsImplementation.cs
@@ -248,7 +248,11 @@ namespace Plugin.Calendars
             appt.Duration = calendarEvent.End - calendarEvent.Start;
             appt.AllDay = calendarEvent.AllDay;
             appt.Location = calendarEvent.Location ?? string.Empty;
-            appt.Reminder = calendarEvent.Reminders?.FirstOrDefault()?.TimeBefore;
+
+            if (calendarEvent.Reminders != null)
+            {
+                appt.Reminder = calendarEvent.Reminders?.FirstOrDefault()?.TimeBefore;
+            }
 
             await appCalendar.SaveAppointmentAsync(appt);
 

--- a/Calendars/Calendars.Plugin.iOSUnified/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.iOSUnified/CalendarsImplementation.cs
@@ -267,7 +267,7 @@ namespace Plugin.Calendars
 
             // If the provided reminders are different from the existing alarms, replace themm
             //
-            if ((calendarEvent.Reminders != null || iosEvent.HasAlarms) &&
+            if (calendarEvent.Reminders != null &&
                 !(calendarEvent.Reminders?.SequenceEqual(iosEvent.Alarms?.Select(alarm => alarm.ToCalendarEventReminder()) ?? Enumerable.Empty<CalendarEventReminder>()) == true))
             {
                 iosEvent.Alarms = calendarEvent.Reminders.Select(reminder => reminder.ToEKAlarm()).ToArray();

--- a/Calendars/Calendars.Plugin.iOSUnified/EKEventExtensions.cs
+++ b/Calendars/Calendars.Plugin.iOSUnified/EKEventExtensions.cs
@@ -1,5 +1,6 @@
 using EventKit;
 using Plugin.Calendars.Abstractions;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Plugin.Calendars
@@ -30,6 +31,7 @@ namespace Plugin.Calendars
                 Location = ekEvent.Location,
                 ExternalID = ekEvent.EventIdentifier,
                 Reminders = ekEvent.Alarms?.Select(alarm => alarm.ToCalendarEventReminder()).ToList()
+                    ?? new List<CalendarEventReminder>()
             };
         }
     }


### PR DESCRIPTION
Should fix issue #68 where adding a new event without setting Reminders would throw an exception on iOS if default alert times were configured in Settings (and make sure that we can actually preserve those default alert times rather than overwrite them)