### PR TITLE
Remove unnecessary null check for EKCalendar.CGColor

### DIFF
--- a/Calendars/Calendars.Plugin.iOSUnified/CalendarsImplementation.cs
+++ b/Calendars/Calendars.Plugin.iOSUnified/CalendarsImplementation.cs
@@ -152,12 +152,7 @@ namespace Plugin.Calendars
             {
                 deviceCalendar = CreateEKCalendar(calendar.Name, calendar.Color);
                 calendar.ExternalID = deviceCalendar.CalendarIdentifier;
-
-                // Update color in case iOS assigned one
-                if (deviceCalendar.CGColor != null)
-                {
-                    calendar.Color = ColorConversion.ToHexColor(deviceCalendar.CGColor);
-                }
+                calendar.Color = ColorConversion.ToHexColor(deviceCalendar.CGColor);
             }
             else
             {


### PR DESCRIPTION
It is now indicated by the SDK as being non-nullable.

(This was also addressed by @chrfin in https://github.com/TheAlmightyBob/Calendars/pull/85, but isn't actually related to the rest of that PR. In that case, in the interest of caution, @maxkoshevoi suggested using `null!` to keep the check... which was a good idea, but since the [Swift documentation](https://developer.apple.com/documentation/eventkit/ekcalendar/1615894-cgcolor) lists it as `CGColor!`, I think it is safe to trust that the updated type is correct and it won't be `null`... and the unit tests should catch if that's wrong)