### PR TITLE
Use GitHub Actions to build test projects

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
         dotnet-version: 5.0.x
         
     - name: Restore dependencies
-      run: nuget restore
+      run: dotnet restore
       
     - name: Build
       run: msbuild /p:Platform=Android /p:Configuration=Release

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,27 @@
+name: Build Android
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        
+    - name: Restore dependencies
+      run: nuget restore
+      
+    - name: Build
+      run: msbuild Tests/Calendars.Plugin.Android.Tests/Calendars.Plugin.Android.Tests.csproj /p:Platform=Android /p:Configuration=Release

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,4 +24,4 @@ jobs:
       run: nuget restore
       
     - name: Build
-      run: msbuild Tests/Calendars.Plugin.Android.Tests/Calendars.Plugin.Android.Tests.csproj /p:Platform=Android /p:Configuration=Release
+      run: msbuild /p:Platform=Android /p:Configuration=Release

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,37 @@
+name: Build iOS
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set default Xamarin SDK versions
+      run: |
+        $VM_ASSETS/select-xamarin-sdk-v2.sh --mono=6.12 --ios=14.14
+    
+    - name: Set default Xcode 12.4
+      run: |
+        XCODE_ROOT=/Applications/Xcode_12.4.0.app
+        echo "MD_APPLE_SDK_ROOT=$XCODE_ROOT" >> $GITHUB_ENV
+        sudo xcode-select -s $XCODE_ROOT
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: msbuild /p:Platform=iPhoneSimulator /p:Configuration=Release


### PR DESCRIPTION
The "real" builds of this library are run via AppVeyor. However, that runs on Windows and only builds the actual library projects. For validation purposes, it seemed nice to actually build the test apps on a Mac (yes technically the Mac is only necessary for the iOS project but simpler to be consistent), e.g. making sure that the library could successfully be referenced by an app.

I've been using AppCenter for this for years, which had the additional benefit of actually _running_ the test apps (not actually running the tests, mind you, but at least made sure that things were in a runnable state), but there seem to be more and more problems with using that for modern projects, and it seems less-accessible for other contributors.